### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stresser
 
-![Latest Version](https://pypip.in/version/stresser/badge.svg)
+![Latest Version](https://img.shields.io/pypi/v/stresser.svg)
 
 Stresser is a large-scale stress testing framework consists of one
 **Commander** (client) and an arbitrary number of **Soldiers** (servers).


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20stresser))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `stresser`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.